### PR TITLE
Complete command confirmation with audio and optional user interface …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,6 @@ log
 
 # Model cache
 src/models/hf_cache/
+
+# Feedback logs
+src/data/feedback_log.jsonl

--- a/src/data/feedback_store.py
+++ b/src/data/feedback_store.py
@@ -1,0 +1,48 @@
+import threading
+import uuid
+import json
+from datetime import datetime
+from pathlib import Path
+
+class FeedbackStore:
+    def __init__(self, log_path=None):
+        self.log_path = Path(log_path) if log_path else Path(__file__).parent / 'feedback_log.jsonl'
+        self._lock = threading.RLock()
+
+    def log_feedback(
+        self,
+        command_id,
+        feedback_type,
+        value,
+        command_text=None,
+        source=None  # verbal | ui (auto-detect if None)
+    ):
+        # Auto-detect source if not explicitly provided
+        if source is None:
+            if str(value).lower() in ("yes", "no"):
+                source = "verbal"
+            elif str(value).lower() in ("up", "down", "thumbs_up", "thumbs_down"):
+                source = "ui"
+            else:
+                source = "unknown"
+
+        record = {
+            "uuid": str(uuid.uuid4()),
+            "command_id": command_id,
+            "command_text": command_text,
+            "type": feedback_type,
+            "value": value,
+            "source": source,
+            "timestamp": datetime.utcnow().isoformat() + "Z"
+        }
+
+        try:
+            with self._lock:
+                with self.log_path.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps(record) + "\n")
+        except Exception as e:
+            # Logging must never crash the server
+            import logging
+            logging.getLogger(__name__).error(
+                f"Failed to write feedback log: {e}"
+            )

--- a/src/presentation/src/App.css
+++ b/src/presentation/src/App.css
@@ -441,3 +441,140 @@
     gap: 0.5rem;
   }
 }
+
+/* Confirmation-ready alert */
+.system-message-alert.confirmation-ready {
+  background-color: #e6f7ee;
+  border-color: #2f9e44;
+  box-shadow: 0 2px 8px rgba(47, 158, 68, 0.15);
+}
+
+.dark-mode .system-message-alert.confirmation-ready {
+  background-color: rgba(47, 158, 68, 0.12);
+  border-color: #40c057;
+  box-shadow: 0 2px 8px rgba(47, 158, 68, 0.2);
+}
+
+.system-message-alert.confirmation-ready .system-message-content strong {
+  color: #2f9e44;
+}
+
+.dark-mode .system-message-alert.confirmation-ready .system-message-content strong {
+  color: #69db7c;
+}
+
+/* ── Confirmation UI ── */
+.confirmation-ui {
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  animation: slideDown 0.2s ease;
+}
+
+.dark-mode .confirmation-ui {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #e8e8e8;
+}
+
+.light-mode .confirmation-ui {
+  background: rgba(0, 0, 0, 0.03);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  color: #222;
+}
+
+/* Verbal cues — displayed as instructional text, not buttons */
+.confirmation-verbal-cues {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.confirmation-cue {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.92rem;
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+.dark-mode .confirmation-cue--yes {
+  background: rgba(47, 158, 68, 0.15);
+  border-left: 3px solid #2f9e44;
+}
+
+.dark-mode .confirmation-cue--no {
+  background: rgba(201, 42, 42, 0.15);
+  border-left: 3px solid #c92a2a;
+}
+
+.light-mode .confirmation-cue--yes {
+  background: rgba(47, 158, 68, 0.08);
+  border-left: 3px solid #2f9e44;
+}
+
+.light-mode .confirmation-cue--no {
+  background: rgba(201, 42, 42, 0.08);
+  border-left: 3px solid #c92a2a;
+}
+
+/* Thumbs section */
+.confirmation-thumbs-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.confirmation-thumbs-toggle {
+  background: transparent;
+  border: none;
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 2px 0;
+  text-align: left;
+  opacity: 0.55;
+  transition: opacity 0.15s;
+}
+
+.dark-mode .confirmation-thumbs-toggle { color: #ccc; }
+.light-mode .confirmation-thumbs-toggle { color: #555; }
+.confirmation-thumbs-toggle:hover { opacity: 0.9; }
+
+.confirmation-thumbs-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.confirmation-btn {
+  flex: 1;
+  padding: 9px 0;
+  border: none;
+  border-radius: 7px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s, transform 0.1s;
+}
+
+.confirmation-btn:focus-visible {
+  outline: 2px solid #4dabf7;
+  outline-offset: 2px;
+}
+
+.confirmation-btn:active { transform: scale(0.97); }
+
+.confirmation-btn--up {
+  background: #2f9e44;
+  color: #fff;
+}
+.confirmation-btn--up:hover { filter: brightness(1.15); }
+
+.confirmation-btn--down {
+  background: #c92a2a;
+  color: #fff;
+}
+.confirmation-btn--down:hover { filter: brightness(1.15); }

--- a/src/presentation/src/App.js
+++ b/src/presentation/src/App.js
@@ -11,6 +11,11 @@ import AccessibilityLayer from './utils/accessibilityLayer';
 const AUDIO_BACKEND_BASE = 'http://localhost:8000';
 
 function App() {
+  // Confirmation state
+  const [awaitingConfirmation, setAwaitingConfirmation] = useState(false);
+  const [lastCommandId, setLastCommandId] = useState(null);
+  const [pendingCommand, setPendingCommand] = useState(null);
+
   const [isListening, setIsListening] = useState(true);
   const [status, setStatus] = useState('listening'); // idle, listening
   const [error, setError] = useState(null);
@@ -24,6 +29,101 @@ function App() {
   const uiClientRef = useRef(null);
   const auditLoggerRef = useRef(null);
   const accessibilityLayerRef = useRef(null);
+
+  // Toggle thumbs button visibility
+  const [showThumbs, setShowThumbs] = useState(true);
+
+  useEffect(() => {
+    const tick = () => {
+      fetch(`${AUDIO_BACKEND_BASE}/status`)
+        .then((r) => r.json())
+        .then((data) => {
+          setUserPrompt(data.user_prompt ?? null);
+          setUserTranscript(data.user_transcript ?? null);
+          setAwaitingConfirmation(data.awaiting_confirmation ?? false);
+          setPendingCommand(data.pending_command ?? null);
+          setLastCommandId(data.last_command ?? null);
+        })
+        .catch(() => {});
+    };
+    tick(); 
+    const interval = setInterval(tick, 400);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Send UI feedback (thumbs) — also triggers execute/cancel on backend
+  const sendThumbsFeedback = (value) => {
+    fetch(`${AUDIO_BACKEND_BASE}/feedback`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command_id: lastCommandId || pendingCommand || 'unknown',
+        feedback_type: 'ui',
+        value,
+        source: 'ui',
+        command_text: pendingCommand || userPrompt || ''
+      })
+    }).then(() => {
+      setAwaitingConfirmation(false);
+      setPendingCommand(null);
+    }).catch(() => {});
+  };
+
+  // Confirmation, only rendered when a complete command is pending verbal yes/no
+  const renderConfirmationUI = () => {
+    if (!awaitingConfirmation) return null;
+    return (
+      <section
+        className="confirmation-ui"
+        aria-label="Awaiting verbal confirmation"
+        aria-live="polite"
+      >
+        {/* Verbal instruction — these are spoken, not clicked */}
+        <div className="confirmation-verbal-cues">
+          <span className="confirmation-cue confirmation-cue--yes" aria-label="Say Yes to confirm">
+            🎙 Say <strong>"Yes"</strong> to confirm
+          </span>
+          <span className="confirmation-cue confirmation-cue--no" aria-label="Say No to cancel">
+            🎙 Say <strong>"No"</strong> to cancel
+          </span>
+        </div>
+
+        {/* Thumbs toggle + buttons */}
+        <div className="confirmation-thumbs-row">
+          <button
+            type="button"
+            className="confirmation-thumbs-toggle"
+            onClick={() => setShowThumbs(prev => !prev)}
+            aria-label={showThumbs ? 'Hide button controls' : 'Show button controls'}
+            title={showThumbs ? 'Hide buttons' : 'Show buttons'}
+          >
+            {showThumbs ? 'Hide buttons ▲' : 'Show buttons ▼'}
+          </button>
+
+          {showThumbs && (
+            <div className="confirmation-thumbs-buttons" role="group" aria-label="Button alternatives">
+              <button
+                type="button"
+                className="confirmation-btn confirmation-btn--up"
+                onClick={() => sendThumbsFeedback('thumbs_up')}
+                aria-label="Thumbs up — confirm command"
+              >
+                👍 Confirm
+              </button>
+              <button
+                type="button"
+                className="confirmation-btn confirmation-btn--down"
+                onClick={() => sendThumbsFeedback('thumbs_down')}
+                aria-label="Thumbs down — cancel command"
+              >
+                👎 Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </section>
+    );
+  };
 
   useEffect(() => {
     // Initialize modules
@@ -62,9 +162,9 @@ function App() {
     } else {
       fetch(`${base}/audio/capture/stop`, { method: 'POST' }).catch(() => {});
     }
-  });
+  }, [isListening]);
 
-  // Poll backend capture status and user_prompt/user_transcript from /status
+  // Poll backend capture status
   useEffect(() => {
     if (!isListening) return;
     const base = AUDIO_BACKEND_BASE;
@@ -83,30 +183,7 @@ function App() {
           }
         })
         .catch(() => {});
-      fetch(`${base}/status`)
-        .then((r) => r.json())
-        .then((data) => {
-          setUserPrompt(data.user_prompt ?? null);
-          setUserTranscript(data.user_transcript ?? null);
-        })
-        .catch(() => {});
     }, 400);
-    return () => clearInterval(interval);
-  }, [isListening]);
-
-  // Poll /status for user_prompt and user_transcript when not in voice mode (e.g. after stop)
-  useEffect(() => {
-    if (isListening) return;
-    const base = AUDIO_BACKEND_BASE;
-    const interval = setInterval(() => {
-      fetch(`${base}/status`)
-        .then((r) => r.json())
-        .then((data) => {
-          setUserPrompt(data.user_prompt ?? null);
-          setUserTranscript(data.user_transcript ?? null);
-        })
-        .catch(() => {});
-    }, 1000);
     return () => clearInterval(interval);
   }, [isListening]);
 
@@ -241,22 +318,30 @@ function App() {
           <div className="main-container">
             <div className="left-panel">
               <StatusIndicator status={status} error={error} isLightMode={isLightMode} />
-              <SpeechInput
-                isListening={isListening}
-                status={status}
-                onAudioData={handleAudioData}
-                onError={handleError}
-                isLightMode={isLightMode}
-                backendBase={AUDIO_BACKEND_BASE}
-              />
+              {(status === 'listening' || awaitingConfirmation) && (
+                <SpeechInput
+                  isListening={isListening}
+                  status={status}
+                  onAudioData={handleAudioData}
+                  onError={handleError}
+                  isLightMode={isLightMode}
+                  backendBase={AUDIO_BACKEND_BASE}
+                />
+              )}
+              {renderConfirmationUI()}
             </div>
             <div className="right-panel">
               {/* System message - always visible, never clipped */}
               {userPrompt && (
-                <div className="system-message-alert" style={{marginBottom: 20, maxWidth: '100%'}}>
-                  <div className="system-message-icon">ℹ️</div>
+                <div
+                  className={`system-message-alert${awaitingConfirmation ? ' confirmation-ready' : ''}`}
+                  style={{marginBottom: 20, maxWidth: '100%'}}
+                >
+                  <div className="system-message-icon">
+                    {awaitingConfirmation ? '✅' : 'ℹ️'}
+                  </div>
                   <div className="system-message-content">
-                    <strong>System Message:</strong>
+                    <strong>{awaitingConfirmation ? 'Ready to Execute:' : 'System Message:'}</strong>
                     <p>{userPrompt}</p>
                   </div>
                 </div>

--- a/src/server.py
+++ b/src/server.py
@@ -23,7 +23,7 @@ from typing import Optional, List
 from contextlib import asynccontextmanager
 
 import numpy as np
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -33,6 +33,7 @@ from control.session_manager import get_browser, start_session, stop_session
 
 from app.command_orchestrator import CommandOrchestrator, OrchestratorError
 from app.speech_to_text_engine import SpeechToTextEngine
+from data.feedback_store import FeedbackStore
 
 # Windows compatibility
 if sys.platform.startswith("win"):
@@ -69,9 +70,16 @@ class StatusResponse(BaseModel):
     user_transcript: Optional[str] = None  # Latest user input
     clarified_command: Optional[str] = None  # LLM-clarified version
     last_command: Optional[str] = None
-    user_prompt: Optional[str] = None
+    user_prompt: Optional[str] = None       # Message shown to user (clarification OR confirmation summary)
+    awaiting_confirmation: bool = False     # True only when a complete command awaits yes/no
+    pending_command: Optional[str] = None   # The command text held until confirmed
 
-
+class FeedbackRequest(BaseModel):
+    command_id: str
+    feedback_type: str
+    value: str
+    source: str
+    command_text: str = None
 # ============================================================================
 # WebSocket Connection Manager
 # ============================================================================
@@ -164,9 +172,14 @@ class VoiceBridgeServer:
         self._clarified_command: Optional[str] = None  # LLM-clarified version
         
         # Conversation context for multi-turn interactions
-        # Format: [{"role": "user|assistant", "content": "...", "timestamp": "..."}]
         self._conversation_context: List[dict] = []
         self._current_user_prompt: Optional[str] = None
+
+        # Confirmation gate: True only while waiting for the user to say yes/no
+        # _pending_command holds the clarified command text until confirmed
+        self._awaiting_confirmation: bool = False
+        self._pending_command: Optional[str] = None
+        self.feedback_store = FeedbackStore()
     
     def _broadcast_state_change(self, state_data, old_state):
         """Broadcast state changes to WebSocket clients"""
@@ -291,17 +304,24 @@ class VoiceBridgeServer:
                     }
                 }
             logger.info(f"Orchestrator clarified command: '{clarified_command}'")
-            # Execute via browser controller (which handles natural language)
-            # Transition to executing state
-            print("**SWITCHED TO EXECUTING")
 
-            self.state_manager.transition_to(AppState.EXECUTING, transcript=clarified_command)
-            execution_result = await self._execute_browser_command(clarified_command)
+            # ----------------------------------------------------------------
+            # Complete command ready → enter confirmation gate.
+            # We stay in LISTENING state; _awaiting_confirmation=True means
+            # the next audio chunk will be routed to _process_confirmation.
+            # ----------------------------------------------------------------
+            self._pending_command = clarified_command
+            self._awaiting_confirmation = True
+            self._current_user_prompt = (
+                f"Ready to execute: \"{clarified_command}\". "
+                "Say yes to confirm or no to cancel."
+            )
+            self._last_command = clarified_command
+
             return {
-                "needs_input": False,
-                "success": True,
-                "command": clarified_command,
-                "details": execution_result
+                "needs_input": True,
+                "awaiting_confirmation": True,
+                "user_prompt": self._current_user_prompt,
             }
             
         except OrchestratorError as e:
@@ -393,6 +413,8 @@ class VoiceBridgeServer:
         if current_state != AppState.LISTENING:
             logger.warning(f"Received audio in unexpected state: {current_state.value}")
             return None
+        elif self._awaiting_confirmation:
+            await self._process_confirmation(audio_data)
         else:
             await self._process_new_command(audio_data)
 
@@ -427,33 +449,27 @@ class VoiceBridgeServer:
             
             # Handle result
             if result.get("needs_input"):
-                # Need clarification
+                # Either a clarification question OR a confirmation prompt, return to LISTENING so the user can respond.
                 self._current_user_prompt = result["user_prompt"]
-                self.state_manager.transition_to(
-                    AppState.LISTENING,
-                    transcript=transcript,
-                    metadata={
-                        "user_prompt": result["user_prompt"],
-                        "context": result.get("context", {})
-                    }
-                )
-                
-                # Add prompt to conversation
+
                 self._conversation_context.append({
                     "role": "assistant",
                     "content": result["user_prompt"],
                     "timestamp": self.state_manager.state_data.timestamp.isoformat()
                 })
-                
-                # Auto-start listening for response
-                if self.is_voice_mode_active:
-                    await asyncio.sleep(0.1)
-                    self.state_manager.transition_to(AppState.LISTENING)
+
+                self.state_manager.transition_to(
+                    AppState.LISTENING,
+                    transcript=transcript,
+                    metadata={"user_prompt": result["user_prompt"]}
+                )
             
             else:
-                # Command executed successfully
+                # Command executed successfully — close the confirmation window
                 self._last_command = transcript
                 self._current_user_prompt = None
+                self._awaiting_confirmation = False
+                self._pending_command = None
                 # Keep user_transcript and clarified_command for display
                 # They will be updated on next user input
                 
@@ -471,6 +487,8 @@ class VoiceBridgeServer:
             logger.error(f"Error processing command: {e}")
             self.state_manager.handle_error(str(e))
             self._current_user_prompt = None
+            self._awaiting_confirmation = False
+            self._pending_command = None
             
             # Return to listening/idle
             await asyncio.sleep(2)
@@ -479,6 +497,94 @@ class VoiceBridgeServer:
             else:
                 self.state_manager.transition_to(AppState.IDLE)
     
+    async def _process_confirmation(self, audio_data: bytes):
+        """
+        Handle a voice yes/no response while _awaiting_confirmation is True.
+
+        yes / yeah / yep          → log verbal feedback, execute pending command
+        no / nope / cancel / etc. → log verbal feedback, discard, back to LISTENING
+        anything else             → treat as a brand-new command
+        """
+        self.state_manager.transition_to(AppState.PROCESSING, audio_data=audio_data)
+
+        try:
+            transcript = await self.transcribe_audio(audio_data)
+            self._user_transcript = transcript
+            word = transcript.strip().lower().rstrip(".,!?")
+
+            if word in ("yes", "yeah", "yep"):
+                self.feedback_store.log_feedback(
+                    command_id=self._pending_command or "unknown",
+                    feedback_type="confirmation",
+                    value="yes",
+                    command_text=self._pending_command,
+                    source="verbal",
+                )
+                logger.info(f"Verbal YES — executing: '{self._pending_command}'")
+                await self._execute_confirmed_command()
+
+            elif word in ("no", "nope", "cancel", "nevermind", "never mind", "stop"):
+                self.feedback_store.log_feedback(
+                    command_id=self._pending_command or "unknown",
+                    feedback_type="confirmation",
+                    value="no",
+                    command_text=self._pending_command,
+                    source="verbal",
+                )
+                logger.info(f"Verbal NO — cancelling: '{self._pending_command}'")
+                await self._cancel_confirmed_command()
+
+            else:
+                # Ambiguous — not a yes/no. Treat as a new command.
+                logger.info(f"Ambiguous reply '{transcript}' — treating as new command")
+                self._reset_confirmation_gate()
+                await self._process_new_command(audio_data)
+
+        except Exception as e:
+            logger.error(f"Error in _process_confirmation: {e}")
+            self._reset_confirmation_gate()
+            self.state_manager.handle_error(str(e))
+            await asyncio.sleep(2)
+            target = AppState.LISTENING if self.is_voice_mode_active else AppState.IDLE
+            self.state_manager.transition_to(target)
+
+    def _reset_confirmation_gate(self):
+        """Clear all confirmation state without triggering any transitions."""
+        self._awaiting_confirmation = False
+        self._pending_command = None
+        self._current_user_prompt = None
+        self._conversation_context = []
+
+    async def _execute_confirmed_command(self):
+        """Execute the pending command and return to LISTENING."""
+        pending = self._pending_command
+        logger.info(f"[CONFIRMATION] Executing confirmed command: {pending}")
+        self._reset_confirmation_gate()
+
+        self.state_manager.transition_to(AppState.EXECUTING, transcript=pending)
+        try:
+            await self._execute_browser_command(pending)
+        except Exception as e:
+            logger.error(f"Execution error after confirmation: {e}")
+            self.state_manager.handle_error(str(e))
+
+        self._last_command = pending
+        await asyncio.sleep(0.1)
+        target = AppState.LISTENING if self.is_voice_mode_active else AppState.IDLE
+        self.state_manager.transition_to(target)
+        logger.info(f"[CONFIRMATION] Command executed, state reset to {target}")
+        if hasattr(self, 'manager') and self.manager:
+            await self.manager.broadcast({"state": self.state_manager.get_state_info()})
+
+    async def _cancel_confirmed_command(self):
+        self._reset_confirmation_gate()
+        await asyncio.sleep(0.1)
+        target = AppState.LISTENING if self.is_voice_mode_active else AppState.IDLE
+        self.state_manager.transition_to(target)
+        logger.info(f"[CONFIRMATION] Command cancelled, state reset to {target}")
+        if hasattr(self, 'manager') and self.manager:
+            await self.manager.broadcast({"state": self.state_manager.get_state_info()})
+
     # ========================================================================
     # Audio Capture Management
     # ========================================================================
@@ -556,15 +662,19 @@ class VoiceBridgeServer:
         status['last_command'] = self._last_command
         status['user_prompt'] = self._current_user_prompt
         status['transcript'] = self._last_transcript or status.get('transcript')
-        status['user_transcript'] = self._user_transcript  # Latest user input
-        status['clarified_command'] = self._clarified_command  # LLM version
+        status['user_transcript'] = self._user_transcript
+        status['clarified_command'] = self._clarified_command
         status['has_conversation_context'] = len(self._conversation_context) > 0
+        status['awaiting_confirmation'] = self._awaiting_confirmation
+        status['pending_command'] = self._pending_command
         return status
     
     def reset(self) -> dict:
         """Reset to idle state."""
         self.is_voice_mode_active = False
         self._current_user_prompt = None
+        self._awaiting_confirmation = False
+        self._pending_command = None
         self._conversation_context = []
         self._user_transcript = None
         self._clarified_command = None
@@ -683,6 +793,45 @@ async def reset_server():
     result = server.reset()
     return {"success": True, "message": "Server reset", "state": result["state"]}
 
+
+@app.post("/feedback")
+async def feedback_endpoint(request: Request):
+    """
+    Receive UI or verbal feedback for a pending confirmation.
+
+    thumbs_up  → log + execute the pending command
+    thumbs_down → log + cancel the pending command
+    Other values → log only (no state change)
+    """
+    if not server:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    data = await request.json()
+    try:
+        value = data.get("value", "")
+        source = data.get("source", "ui")
+        command_id = data.get("command_id") or server._pending_command or "unknown"
+        command_text = data.get("command_text") or server._pending_command
+
+        server.feedback_store.log_feedback(
+            command_id=command_id,
+            feedback_type=data.get("feedback_type", "ui"),
+            value=value,
+            command_text=command_text,
+            source=source,
+        )
+
+        if server._awaiting_confirmation:
+            if value in ("thumbs_up", "yes"):
+                logger.info(f"UI confirm — executing: '{server._pending_command}'")
+                asyncio.create_task(server._execute_confirmed_command())
+            elif value in ("thumbs_down", "no"):
+                logger.info(f"UI cancel — discarding: '{server._pending_command}'")
+                asyncio.create_task(server._cancel_confirmed_command())
+
+        return {"success": True}
+    except Exception as e:
+        logger.error(f"Feedback logging failed: {e}")
+        return {"success": False, "error": str(e)}
 
 @app.get("/health")
 async def health_check():

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -131,7 +131,7 @@ class StateManager:
         valid_transitions = {
             AppState.IDLE: [AppState.LISTENING],
             AppState.LISTENING: [AppState.PROCESSING, AppState.ERROR],
-            AppState.PROCESSING: [AppState.EXECUTING, AppState.ERROR],
+            AppState.PROCESSING: [AppState.EXECUTING, AppState.ERROR, AppState.LISTENING],
             AppState.EXECUTING: [AppState.IDLE, AppState.LISTENING, AppState.ERROR],
             AppState.ERROR: [AppState.IDLE, AppState.LISTENING]
         }


### PR DESCRIPTION
Closes #238
This adds a confirmation step before running commands, so users can confirm the complete command before it is executed

- Shows the full command before execution
- Lets users confirm by saying “yes” or “no” out loud
- Optional thumbs up/down buttons for quick feedback
- Feedback is logged with source and value
<img width="1247" height="520" alt="image" src="https://github.com/user-attachments/assets/047f10b2-2714-499a-8909-a25f88e7e125" />
