### PR TITLE
add prompt cache with initial_intent handling and cache APIs

### DIFF
--- a/src/app/command_cache.py
+++ b/src/app/command_cache.py
@@ -1,0 +1,189 @@
+"""
+CommandCache — src/app/command_cache.py
+
+Persistent JSON-backed cache mapping a normalized user transcript
+to a clarified browser command.
+
+Normalization
+    - Removes non-semantic filler words (e.g., "hey", "please", "uh")
+    - Preserves verbs and meaningful prepositions (e.g., "to", "on", "for")
+
+        "Hey can you go to Gmail"  ->  "go to gmail"
+        "search for cats"          ->  "search for cats"
+
+Collision handling
+    If two transcripts normalize to the same key, the newer mapping is
+    stored under its verbatim lowercase form. If normalization does not
+    change the key, the existing mapping is retained.
+
+Durability
+    - Atomic writes (temp file + os.replace)
+    - threading.Lock protects concurrent access (e.g., VAD thread / FastAPI)
+"""
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("CommandCache")
+
+_DEFAULT_PATH = Path(__file__).resolve().parent.parent.parent / "command_cache.json"
+
+# Words removed during key normalization.
+# Verbs and meaningful prepositions are intentionally preserved.
+_IGNORED_TOKENS: frozenset = frozenset({
+    "hey", "hi", "hello", "please", "can", "you", "uh", "um", "like", "a", "an", "the",
+})
+
+
+class CommandCache:
+    """Persistent transcript -> clarified-command cache with normalisation and collision handling."""
+
+    def __init__(self, path=None):
+        self._path = Path(path) if path else _DEFAULT_PATH
+        self._lock = threading.Lock()
+        self._store: dict = {}
+        self._load()
+
+    def get(self, transcript: str) -> Optional[str]:
+        """Return cached command or None. Lookup order: checks normalized key then verbatim fallback."""
+        sk = self._clean_key(transcript)
+        vk = transcript.lower().strip()
+        with self._lock:
+            result = self._store.get(sk) or (self._store.get(vk) if vk != sk else None)
+        if result:
+            logger.info("Cache HIT  '%s' -> '%s'", sk, result)
+        else:
+            logger.debug("Cache MISS '%s'", sk)
+        return result
+
+    def set(self, transcript: str, clarified_command: str) -> None:
+        """
+        Store clarified_command for transcript and flush to disk.
+        transcript should be pre-normalised (pass _root_transcript, not raw input).
+        Idempotent : no-op if the mapping already exists.
+        """
+        sk = self._clean_key(transcript)
+        vk = transcript.lower().strip()
+
+        with self._lock:
+            existing = self._store.get(sk)
+            if existing and existing != clarified_command:
+                if vk != sk:
+                    key = vk  # Store under verbatim key on normalization collision
+                    logger.warning("Collision on '%s' — storing under verbatim key.", sk)
+                else:
+                    logger.warning("Collision on '%s' — keeping existing mapping.", sk)
+                    return
+            else:
+                key = sk
+
+            if self._store.get(key) == clarified_command:
+                return
+
+            self._store[key] = clarified_command
+            self._flush()
+
+        logger.info("Cache SET  '%s' -> '%s'", key, clarified_command)
+
+    def invalidate(self, transcript: str) -> bool:
+        """Remove all cached entries for transcript.
+
+        Returns True if at least one entry was removed.
+        """
+        sk = self._clean_key(transcript)
+        vk = transcript.lower().strip()
+        with self._lock:
+            removed = bool(self._store.pop(sk, None))
+            if vk != sk:
+                removed |= bool(self._store.pop(vk, None))
+            if removed:
+                self._flush()
+        if removed:
+            logger.info("Cache INVALIDATED '%s'", transcript)
+        return removed
+
+    def clear(self) -> int:
+        """Remove all cached entries and delete the cache file.
+
+        Returns the number of entries removed.
+        """
+        with self._lock:
+            count = len(self._store)
+            self._store.clear()
+            try:
+                self._path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("Could not delete cache file: %s", exc)
+        logger.info("Cache CLEARED (%d entries removed)", count)
+        return count
+
+    @property
+    def size(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # ── Normalisation ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _clean_key(text: str) -> str:
+        """
+            Normalize a transcript for use as a cache key.
+
+            - Lowercase
+            - Remove trailing sentence punctuation
+            - Remove ignored tokens
+
+            "Hey can you please open Gmail"  ->  "open gmail"
+            "hi please go to youtube"        ->  "go to youtube"
+            "open email."                    ->  "open email"
+        """
+        # Remove trailing punctuation per token to avoid STT-induced key mismatches.
+        _PUNCT = str.maketrans("", "", ".,!?;:")
+        tokens = text.lower().split()
+        tokens = [t.translate(_PUNCT) for t in tokens]
+        kept = [t for t in tokens if t and t not in _IGNORED_TOKENS]
+        return " ".join(kept) if kept else text.lower().strip()
+
+    # ── Persistence ──────────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        """Load from disk on startup. Silent on missing file; warns and starts fresh on corruption."""
+        if not self._path.exists():
+            logger.info("No cache file found at %s; starting empty", self._path)
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                raise ValueError("Expected a JSON object")
+            self._store = {k: str(v) for k, v in data.items()}
+            logger.info("Loaded %d entries from %s", len(self._store), self._path)
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
+            logger.warning("Cache unreadable (%s); starting empty", exc)
+            self._store = {}
+
+    def _flush(self) -> None:
+        """Atomically write store to disk via temp file + os.replace. Caller must hold _lock."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(dir=self._path.parent, prefix=".cmd_cache_", suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(self._store, f, indent=2, ensure_ascii=False)
+                os.replace(tmp, self._path)
+            except Exception:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
+        except OSError as exc:
+            logger.error("Failed to write cache: %s", exc)

--- a/src/app/command_orchestrator.py
+++ b/src/app/command_orchestrator.py
@@ -1,18 +1,24 @@
 """
-CommandOrchestrator Module - Simplified Version
+CommandOrchestrator
 
 Handles command clarification for natural language browser control:
-- Determines if user intent is clear
-- Asks clarifying questions when needed
-- Returns clarified natural language commands
-- The actual browser automation is handled by an LLM-powered browser controller
+Responsibilities:
+1. Translate user transcripts into executable browser commands
+2. Request clarification when intent is ambiguous
+3. Maintain multi-turn conversational state
+4. Enforce safety guardrails
+5. Use a persistent CommandCache so repeated commands (including those
+   previously clarified) bypass the LLM
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
+
+from app.command_cache import CommandCache
 
 
 # ============================================================================
@@ -26,17 +32,13 @@ class OrchestratorResponse:
     """
     # Indicates if we need user input before proceeding
     needs_clarification: bool
-    
     # If needs_clarification=True, this is the question to ask the user
     user_prompt: Optional[str] = None
-    
     # If needs_clarification=False, this is the clarified natural language command
     # to pass to the browser controller
     clarified_command: Optional[str] = None
-    
     # Additional context for debugging
     reasoning: Optional[str] = None
-    
     # Metadata from the orchestrator's processing
     metadata: Optional[Dict[str, Any]] = None
 
@@ -67,55 +69,60 @@ class InferenceError(OrchestratorError):
 class CommandOrchestrator:
     """
     Orchestrates natural language to browser commands using an LLM.
-    
     Key responsibilities:
     1. Parse user transcript into browser commands
     2. Ask clarifying questions when needed
     3. Maintain conversation context for multi-turn interactions
     4. Apply safety guardrails
+    5. Maintain a persistent cache (CommandCache) so repeat commands, including those that previously required clarification,
+       are served instantly without any LLM call.
     """
-    
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         model_id: str = "gemini-2.5-flash",
-        prompt_path: Optional[str] = None
+        prompt_path: Optional[str] = None,
+        cache_path: Optional[str] = None,
     ):
         """
         Initialize the orchestrator.
-        
         Args:
             api_key: LLM API key (or use GEMINI_API_KEY env var)
             model_id: Model to use
             prompt_path: Path to system prompt file
+            cache_path: Optional override for command_cache.json location
         """
         self._api_key = api_key or os.environ.get("GEMINI_API_KEY")
         if not self._api_key:
             raise InitializationError("GEMINI_API_KEY not found")
-        
         # Initialize the Gen AI Client
         try:
             from google import genai
             self.client = genai.Client(api_key=self._api_key)
         except ImportError:
             raise InitializationError("google-genai package not installed. Run: pip install google-genai")
-        
         self.model_id = model_id
-        
         # Load system prompt
         if prompt_path and Path(prompt_path).exists():
             self.system_prompt = Path(prompt_path).read_text(encoding="utf-8")
         else:
-            # Default prompt
             self.system_prompt = self._get_default_system_prompt()
-        
         # Conversation history for multi-turn interactions
         # Format: [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]
         self.conversation_history: List[Dict[str, str]] = []
-        
         # Current state
         self.current_goal: Optional[str] = None
-    
+        # First-turn transcript used as the cache key.
+        # Set via `initial_intent` and preserved across clarification turns.
+        self._root_transcript: Optional[str] = None
+
+        # Persistent command cache: loaded from disk on startup, written on every newly learned command. Survives restarts
+        self.cache = CommandCache(path=cache_path)
+        logging.getLogger("CommandOrchestrator").info(
+            "Cache loaded from '%s' (%d entries)", self.cache.path, self.cache.size
+        )
+
     def _get_default_system_prompt(self) -> str:
         """Default system prompt if no file provided."""
         return """
@@ -204,24 +211,27 @@ Note: When executing a command to play a video, ensure the video remains playing
 
 Be concise and helpful. Only ask for clarification when truly necessary. The browser controller is intelligent and can handle natural language well.
 """
-    
+
     async def process(
         self,
         user_input: str,
-        conversation_context: Optional[List[Dict[str, str]]] = None
+        conversation_context: Optional[List[Dict[str, str]]] = None,
+        initial_intent: Optional[str] = None,
     ) -> OrchestratorResponse:
         """
-        Process user input and return either a clarified command or a clarification request.
-        
-        This method determines if the user's intent is clear. If clear, it returns a 
-        clarified natural language command to pass to the browser controller. If unclear,
-        it asks a clarifying question.
-        
+        Process user input and return either a clarified command or a
+        clarification request. Process user input using a cache-first strategy.
+            - Reject empty input early
+            - On first turn, check cache using `initial_intent`
+            - Skip cache lookup on clarification turns
+            - Cache writes occur server-side after confirmed execution
+       
         Args:
             user_input: The user's transcript or response
             conversation_context: Optional conversation history from the server
                                 Format: [{"role": "user|assistant", "content": "..."}]
-        
+            initial_intent: Canonical first-turn transcript for cache lookup
+
         Returns:
             OrchestratorResponse indicating what to do next:
             - If needs_clarification=True: Ask user the question in user_prompt
@@ -232,48 +242,73 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
             response = await orchestrator.process("Open Gmail")
             # response.needs_clarification = False
             # response.clarified_command = "Navigate to Gmail"
-            
-            # Needs clarification
-            response = await orchestrator.process("Go to Google")
-            # response.needs_clarification = True
-            # response.user_prompt = "Which Google service? Google.com, Gmail, ..."
+            # cache stored: "open email" -> "Navigate to Gmail"
         """
+        # Reject empty input
+        if not user_input or not user_input.strip():
+            return OrchestratorResponse(
+                needs_clarification=True,
+                user_prompt="I didn't catch that. Could you repeat your command?",
+                metadata={"original_input": user_input, "rejected": "empty_input"},
+            )
+
+        # First-turn transcript used as the cache key.
+        # Provided by the server before conversation state is updated.
+        if initial_intent is not None:
+            self._root_transcript = initial_intent
+
+        is_first_turn = initial_intent is not None
+
+        # Cache lookup on first turn only
+        if is_first_turn:
+            cached_command = self.cache.get(self._root_transcript)
+            if cached_command is not None:
+                # Cache hit, return without touching the LLM.
+                return OrchestratorResponse(
+                    needs_clarification=False,
+                    clarified_command=cached_command,
+                    metadata={"original_input": user_input, "cache_hit": True},
+                )
+
         # Build conversation context
         messages = []
-        
+
         # Add conversation history if provided
         if conversation_context:
             messages.extend(conversation_context)
-        
+
         # Add current user input
         messages.append({
             "role": "user",
             "content": user_input
         })
-        
+
         # Call LLM
         try:
             response_text = await self._call_llm(messages)
-            
+
             # Parse response
-            return self._parse_response(response_text, user_input)
-            
+            response = self._parse_response(response_text, user_input)
+
         except Exception as e:
             raise InferenceError(f"Failed to process input: {str(e)}")
-    
+
+        # Cache writes occur server-side after confirmed execution.
+        return response
+
     async def _call_llm(self, messages: List[Dict[str, str]]) -> str:
         """
         Call the LLM API with the conversation history.
-        
+
         Args:
             messages: Conversation messages
-            
+
         Returns:
             LLM response text
         """
         try:
             from google.genai import types
-            
+
             # Construct the full conversation with system prompt
             full_messages = [
                 types.Content(
@@ -281,7 +316,7 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
                     parts=[types.Part(text=self.system_prompt)]
                 )
             ]
-            
+
             # Add conversation messages
             for msg in messages:
                 role = "user" if msg["role"] == "user" else "model"
@@ -291,7 +326,7 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
                         parts=[types.Part(text=msg["content"])]
                     )
                 )
-            
+
             # Generate response
             response = self.client.models.generate_content(
                 model=self.model_id,
@@ -301,20 +336,20 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
                     max_output_tokens=512,
                 )
             )
-            
+
             return response.text
-            
+
         except Exception as e:
             raise InferenceError(f"LLM API call failed: {str(e)}")
-    
+
     def _parse_response(self, response_text: str, original_input: str) -> OrchestratorResponse:
         """
         Parse LLM response into an OrchestratorResponse.
-        
+
         Args:
             response_text: Raw LLM response
             original_input: Original user input
-            
+
         Returns:
             Parsed OrchestratorResponse
         """
@@ -326,10 +361,10 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
                 cleaned = "\n".join(lines[1:-1])
                 if cleaned.startswith("json"):
                     cleaned = cleaned[4:].strip()
-            
+
             # Parse JSON
             data = json.loads(cleaned)
-            
+
             # Check if it's a clarification request
             if data.get("needs_clarification"):
                 return OrchestratorResponse(
@@ -337,16 +372,16 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
                     user_prompt=data.get("question", "Could you clarify what you'd like me to do?"),
                     metadata={"original_input": original_input}
                 )
-            
+
             # Otherwise, it's a clarified command
             clarified_command = data.get("clarified_command", original_input)
-            
+
             return OrchestratorResponse(
                 needs_clarification=False,
                 clarified_command=clarified_command,
                 metadata={"original_input": original_input}
             )
-            
+
         except (json.JSONDecodeError, KeyError) as e:
             # If we can't parse the response, treat it as needing clarification
             return OrchestratorResponse(
@@ -355,12 +390,44 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
                 reasoning=f"Failed to parse LLM response: {str(e)}",
                 metadata={"original_input": original_input, "raw_response": response_text}
             )
-    
+
     def reset(self):
         """Reset orchestrator state."""
         self.conversation_history = []
         self.current_goal = None
+        self._root_transcript = None  # cleared so next first-turn sets a fresh root
 
+    def get_cache_stats(self) -> dict:
+        """Return cache statistics."""
+        if hasattr(self, 'cache') and self.cache is not None:
+            return {
+                "size": len(self.cache._store),  
+                "file_path": str(self.cache.path), 
+                "status": "active"
+            }
+        return {
+            "size": 0,
+            "status": "inactive", 
+            "error": "Cache not initialized"
+        }
+
+    def invalidate_cached_command(self, transcript: str) -> bool:
+        """
+        Remove the cached entry for the given transcript.
+
+        Returns:
+            True if an entry was removed, otherwise False.
+        """
+        return self.cache.invalidate(transcript)
+
+    def clear_cache(self) -> int:
+        """
+        Clear all cached commands and delete the cache file.
+
+        Returns:
+            Number of entries removed.
+        """
+        return self.cache.clear()
     @staticmethod
     def apply_guardrails(command: str) -> (bool, str):
         """
@@ -398,23 +465,24 @@ Be concise and helpful. Only ask for clarification when truly necessary. The bro
 def create_orchestrator(
     api_key: Optional[str] = None,
     model_id: str = "gemini-3.5-flash",
-    prompt_path: Optional[str] = None
+    prompt_path: Optional[str] = None,
+    cache_path: Optional[str] = None,
 ) -> CommandOrchestrator:
     """
     Factory function to create a CommandOrchestrator.
-    
+
     Args:
         api_key: LLM API key
-        model_id: Model to use
+        model_id:    Model to use
         prompt_path: Path to system prompt
-        
+        cache_path:  Override path for command_cache.json
+
     Returns:
         Initialized CommandOrchestrator
     """
     return CommandOrchestrator(
         api_key=api_key,
         model_id=model_id,
-        prompt_path=prompt_path
+        prompt_path=prompt_path,
+        cache_path=cache_path,
     )
-
-

--- a/src/server.py
+++ b/src/server.py
@@ -23,7 +23,7 @@ from typing import Optional, List
 from contextlib import asynccontextmanager
 
 import numpy as np
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Request
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Request, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -73,6 +73,7 @@ class StatusResponse(BaseModel):
     user_prompt: Optional[str] = None       # Message shown to user (clarification OR confirmation summary)
     awaiting_confirmation: bool = False     # True only when a complete command awaits yes/no
     pending_command: Optional[str] = None   # The command text held until confirmed
+    cache_stats: Optional[dict] = None
 
 class FeedbackRequest(BaseModel):
     command_id: str
@@ -175,6 +176,11 @@ class VoiceBridgeServer:
         self._conversation_context: List[dict] = []
         self._current_user_prompt: Optional[str] = None
 
+        # Canonical first-turn transcript for the current session.
+        # Captured before conversation context is updated and used as the cache key.
+        # Cleared after execution, cancellation, error, or reset.
+        self._initial_intent: Optional[str] = None
+
         # Confirmation gate: True only while waiting for the user to say yes/no
         # _pending_command holds the clarified command text until confirmed
         self._awaiting_confirmation: bool = False
@@ -230,7 +236,8 @@ class VoiceBridgeServer:
     async def parse_and_execute_command(
         self,
         transcript: str,
-        conversation_context: Optional[List[dict]] = None
+        conversation_context: Optional[List[dict]] = None,
+        initial_intent: Optional[str] = None,
     ) -> dict:
         """
         Parse transcript and execute browser command.
@@ -274,10 +281,11 @@ class VoiceBridgeServer:
                         "content": msg["content"]
                     })
             
-            # Call orchestrator
+            # Call orchestrator. Pass initial_intent so it can use the first-turn transcript as the cache key.
             response = await self.command_orchestrator.process(
                 user_input=transcript,
-                conversation_context=orchestrator_context
+                conversation_context=orchestrator_context,
+                initial_intent=initial_intent,
             )
             
             # Step 2: Handle clarification
@@ -312,10 +320,17 @@ class VoiceBridgeServer:
             # ----------------------------------------------------------------
             self._pending_command = clarified_command
             self._awaiting_confirmation = True
-            self._current_user_prompt = (
-                f"Ready to execute: \"{clarified_command}\". "
-                "Say yes to confirm or no to cancel."
-            )
+            # Build user-facing command summary.
+            # Remove continuation clauses (e.g., "and keep", "until", "while")
+            # so the confirmation prompt shows only the primary action.
+            _trim_markers = [" and keep", " and keep it", " until the user", " while ", " unless"]
+            _display = clarified_command
+            for _marker in _trim_markers:
+                if _marker in _display.lower():
+                    _idx = _display.lower().index(_marker)
+                    _display = _display[:_idx]
+            _display = _display.rstrip(".,; ")
+            self._current_user_prompt = f'"{_display}" — say yes to confirm or no to cancel.'
             self._last_command = clarified_command
 
             return {
@@ -434,6 +449,14 @@ class VoiceBridgeServer:
             self._last_transcript = transcript
             self._user_transcript = transcript  # Store latest user input
             
+            # Capture initial intent before appending — empty context means first turn
+            if not self._conversation_context:
+                self._initial_intent = (
+                    self.command_orchestrator.cache._clean_key(transcript)
+                    if self.command_orchestrator else transcript.lower().strip()
+                )
+                logger.info(f"Session start: initial_intent='{self._initial_intent}'")
+
             # Add to conversation context
             self._conversation_context.append({
                 "role": "user",
@@ -441,10 +464,11 @@ class VoiceBridgeServer:
                 "timestamp": self.state_manager.state_data.timestamp.isoformat()
             })
             
-            # Parse and execute
+            # Parse and execute. Pass initial_intent for cache consistency.
             result = await self.parse_and_execute_command(
                 transcript,
-                self._conversation_context
+                self._conversation_context,
+                initial_intent=self._initial_intent,
             )
             
             # Handle result
@@ -489,6 +513,7 @@ class VoiceBridgeServer:
             self._current_user_prompt = None
             self._awaiting_confirmation = False
             self._pending_command = None
+            self._initial_intent = None
             
             # Return to listening/idle
             await asyncio.sleep(2)
@@ -554,12 +579,24 @@ class VoiceBridgeServer:
         self._pending_command = None
         self._current_user_prompt = None
         self._conversation_context = []
+        self._initial_intent = None  # Reset session root transcript
 
     async def _execute_confirmed_command(self):
         """Execute the pending command and return to LISTENING."""
         pending = self._pending_command
+        initial_intent = self._initial_intent  # capture before reset clears it
         logger.info(f"[CONFIRMATION] Executing confirmed command: {pending}")
         self._reset_confirmation_gate()
+
+        # Persist mapping after user confirmation.
+        # Stores initial_intent -> confirmed command only.
+        # Prevents partial or unverified commands from entering the cache.
+        if self.command_orchestrator and initial_intent and pending:
+            self.command_orchestrator.cache.set(initial_intent, pending)
+            logger.info(
+                "Cache WRITE (post-confirmation): '%s' -> '%s'",
+                initial_intent, pending,
+            )
 
         self.state_manager.transition_to(AppState.EXECUTING, transcript=pending)
         try:
@@ -667,19 +704,24 @@ class VoiceBridgeServer:
         status['has_conversation_context'] = len(self._conversation_context) > 0
         status['awaiting_confirmation'] = self._awaiting_confirmation
         status['pending_command'] = self._pending_command
+        if self.command_orchestrator:
+            status['cache_stats'] = self.command_orchestrator.get_cache_stats()
         return status
     
     def reset(self) -> dict:
-        """Reset to idle state."""
         self.is_voice_mode_active = False
         self._current_user_prompt = None
-        self._awaiting_confirmation = False
-        self._pending_command = None
         self._conversation_context = []
         self._user_transcript = None
         self._clarified_command = None
+        self._initial_intent = None
         if self.command_orchestrator:
+            # Reset conversation state; persistent cache remains intact.
             self.command_orchestrator.reset()
+            logger.info(
+                "Orchestrator reset. Cache preserved (%d entries).",
+                self.command_orchestrator.cache.size,
+            )
         self.state_manager.reset()
         return {"success": True, "state": "idle"}
 
@@ -874,6 +916,37 @@ async def websocket_endpoint(websocket: WebSocket):
         logger.error(f"WebSocket error: {e}")
         server.connection_manager.disconnect(websocket)
 
+
+@app.get("/cache/stats")
+async def cache_stats():
+    """Return command cache metadata."""
+    if not server or not server.command_orchestrator:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    return server.command_orchestrator.get_cache_stats()
+
+
+@app.delete("/cache/entry")
+async def cache_invalidate_entry(
+    transcript: str = Query(..., description="The transcript to remove from cache")
+):
+    """
+    Remove a cached entry for the given transcript.
+    """
+    if not server or not server.command_orchestrator:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    removed = server.command_orchestrator.invalidate_cached_command(transcript)
+    return {"removed": removed, "transcript": transcript}
+
+
+@app.delete("/cache/all")
+async def cache_clear_all():
+    """
+    Clear all cached commands and delete the backing file.
+    """
+    if not server or not server.command_orchestrator:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    count = server.command_orchestrator.clear_cache()
+    return {"cleared": True, "entries_removed": count}
 
 # ============================================================================
 # Run Server


### PR DESCRIPTION
Closes https://github.com/speech-buddies/VoiceBridge/issues/242
Cache to avoid repeat LLM calls.
initial_intent tracking in VoiceBridgeServer for multi-turn sessions to ensure root intent -> final command mapping.
Cache writes occur only after user confirmation to guarantee accuracy.
New API endpoints for cache management

If not found in cache (regular flow + gets added to cache):
<img width="875" height="277" alt="image" src="https://github.com/user-attachments/assets/29a4f21e-7f94-4f43-adba-78fa4ab48b4e" />
<img width="877" height="389" alt="image" src="https://github.com/user-attachments/assets/58b782ab-89e4-48e6-bee6-664fef10ea75" />

Repeating the same request (cache hit):
<img width="862" height="389" alt="image" src="https://github.com/user-attachments/assets/775b089d-8541-40bb-b279-3edbaa638705" />
